### PR TITLE
Include workaround for tribe_get_events

### DIFF
--- a/inc/admin/class-rtec-admin-registrations.php
+++ b/inc/admin/class-rtec-admin-registrations.php
@@ -171,9 +171,6 @@ class RTEC_Admin_Registrations {
 				}
 			}
 
-			$args = apply_filters( 'rtec_registration_overview_query_args', $args, $this->settings );
-
-			return get_posts( $args );
 		}  elseif ( $settings['qtype'] === 'hid' ) {
 
 			$post_type = defined( 'Tribe__Events__Main::POSTTYPE' ) ? Tribe__Events__Main::POSTTYPE : 'tribe_events';
@@ -244,9 +241,6 @@ class RTEC_Admin_Registrations {
 				}
 			}
 
-			$args = apply_filters( 'rtec_registration_overview_query_args', $args, $this->settings );
-
-			return get_posts( $args );
 		} else {
 			$args = array(
 				'posts_per_page' => $this->posts_per_page,
@@ -300,6 +294,10 @@ class RTEC_Admin_Registrations {
 		}
 
 		$args = apply_filters( 'rtec_registration_overview_query_args', $args, $this->settings );
+
+		if ( isset( $args['post_type'] ) ) {
+			return get_posts( $args );
+		}
 
 		return tribe_get_events( $args );
 	}


### PR DESCRIPTION
https://github.com/craigschlegel/registrations-for-the-events-calendar/issues/95

Ended up not making any changes due to inability to replicate the specific problem but provided a hook to use get_posts instead of tribe_get_events to do event queries